### PR TITLE
altテキストを検証できないバグを修正

### DIFF
--- a/src/topics/topics/watanare-topic.ts
+++ b/src/topics/topics/watanare-topic.ts
@@ -132,12 +132,9 @@ export class WatanareTopic implements Topic {
       return { isMatch: true, reason: 'text' }
     }
     // alt
-    const alts = (() => {
-      if (isEmbedImages(record.embed)) {
-        return record.embed.images.map((image) => image.alt)
-      }
-      return undefined
-    })()
+    const alts = isEmbedImages(record.embed)
+      ? record.embed.images.map((image) => image.alt)
+      : undefined
     if (alts) {
       for (const alt of alts) {
         if (regex.test(alt)) {


### PR DESCRIPTION
`isImage`型ガード関数はここで使用できない
embedの型を見れば一発